### PR TITLE
Sync D4H member groups

### DIFF
--- a/lib/app/adapter/d4h.ex
+++ b/lib/app/adapter/d4h.ex
@@ -211,6 +211,21 @@ defmodule App.Adapter.D4H do
     |> Enum.map(&D4H.QualificationAward.build(&1))
   end
 
+  def fetch_groups(context) do
+    response = Req.get!(context, url: "/member-groups", params: [size: -1])
+
+    response.body["results"]
+    |> Enum.map(&D4H.Group.build(&1))
+  end
+
+  def fetch_group_memberships(context, page) do
+    response =
+      Req.get!(context, url: "/member-group-memberships", params: [page: page, size: 1000])
+
+    response.body["results"]
+    |> Enum.map(&D4H.GroupMembership.build(&1))
+  end
+
   def fetch_tags(context) do
     response = Req.get!(context, url: "/tags", params: [size: -1])
     response.body["results"] |> Enum.map(&D4H.Tag.build(&1))

--- a/lib/app/adapter/d4h/group.ex
+++ b/lib/app/adapter/d4h/group.ex
@@ -1,0 +1,11 @@
+defmodule App.Adapter.D4H.Group do
+  defstruct d4h_group_id: nil,
+            title: nil
+
+  def build(record) do
+    %__MODULE__{
+      d4h_group_id: record["id"],
+      title: record["title"]
+    }
+  end
+end

--- a/lib/app/adapter/d4h/group_membership.ex
+++ b/lib/app/adapter/d4h/group_membership.ex
@@ -1,0 +1,15 @@
+defmodule App.Adapter.D4H.GroupMembership do
+  alias App.Adapter.D4H.Parse
+
+  defstruct d4h_group_membership_id: nil,
+            d4h_member_id: nil,
+            d4h_group_id: nil
+
+  def build(record) do
+    %__MODULE__{
+      d4h_group_membership_id: record["id"],
+      d4h_member_id: Parse.member_id(record["member"]),
+      d4h_group_id: record["group"]["id"]
+    }
+  end
+end

--- a/lib/app/model/group.ex
+++ b/lib/app/model/group.ex
@@ -1,0 +1,54 @@
+defmodule App.Model.Group do
+  use App, :model
+
+  alias App.Field.TrimmedString
+  alias App.Model.Group
+  alias App.Model.GroupMember
+  alias App.Model.Team
+  alias App.Repo
+
+  schema "groups" do
+    belongs_to :team, Team
+    has_many :group_members, GroupMember
+    field :d4h_group_id, :integer
+    field :title, TrimmedString
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def build_new_changeset(params \\ %{}), do: build_changeset(%Group{}, params)
+
+  def build_changeset(data, params \\ %{}) do
+    data
+    |> cast(params, [
+      :team_id,
+      :d4h_group_id,
+      :title
+    ])
+    |> validate_required([
+      :team_id,
+      :d4h_group_id,
+      :title
+    ])
+  end
+
+  def scope(q, team_id: team_id), do: where(q, team_id: ^team_id)
+
+  def get_all(team_id) do
+    Group
+    |> where([r], r.team_id == ^team_id)
+    |> order_by([r], asc: r.title)
+    |> Repo.all()
+  end
+
+  def get_by(params), do: Repo.get_by(Group, params)
+
+  def insert!(params) do
+    changeset = Group.build_new_changeset(params)
+    Repo.insert!(changeset)
+  end
+
+  def update!(%Group{} = record, params) do
+    changeset = Group.build_changeset(record, params)
+    Repo.update!(changeset)
+  end
+end

--- a/lib/app/model/group_member.ex
+++ b/lib/app/model/group_member.ex
@@ -1,0 +1,43 @@
+defmodule App.Model.GroupMember do
+  use App, :model
+
+  alias App.Model.Group
+  alias App.Model.GroupMember
+  alias App.Model.Member
+  alias App.Repo
+
+  schema "group_members" do
+    belongs_to :group, Group
+    belongs_to :member, Member
+    field :d4h_group_membership_id, :integer
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def build_new_changeset(params \\ %{}), do: build_changeset(%GroupMember{}, params)
+
+  def build_changeset(data, params \\ %{}) do
+    data
+    |> cast(params, [
+      :group_id,
+      :member_id,
+      :d4h_group_membership_id
+    ])
+    |> validate_required([
+      :group_id,
+      :member_id,
+      :d4h_group_membership_id
+    ])
+  end
+
+  def get_by(params), do: Repo.get_by(GroupMember, params)
+
+  def insert!(params) do
+    changeset = GroupMember.build_new_changeset(params)
+    Repo.insert!(changeset)
+  end
+
+  def update!(%GroupMember{} = record, params) do
+    changeset = GroupMember.build_changeset(record, params)
+    Repo.update!(changeset)
+  end
+end

--- a/lib/app/model/member.ex
+++ b/lib/app/model/member.ex
@@ -5,6 +5,7 @@ defmodule App.Model.Member do
   alias App.Model.Activity
   alias App.Model.Attendance
   alias App.Model.Member
+  alias App.Model.GroupMember
   alias App.Model.MemberQualificationAward
   alias App.Model.TaxCreditLetter
   alias App.Model.Team
@@ -15,6 +16,8 @@ defmodule App.Model.Member do
     belongs_to :team, Team
     has_many :attendances, Attendance, where: [status: "attending"]
     has_many :activities, through: [:attendances, :activity]
+    has_many :group_members, GroupMember
+    has_many :groups, through: [:group_members, :group]
     has_many :member_qualification_awards, MemberQualificationAward
     has_many :qualifications, through: [:member_qualification_awards, :qualification]
     has_many :tax_credit_letters, TaxCreditLetter

--- a/lib/app/operation/RefreshD4HData/upsert_group_memberships.ex
+++ b/lib/app/operation/RefreshD4HData/upsert_group_memberships.ex
@@ -1,0 +1,82 @@
+defmodule App.Operation.RefreshD4HData.UpsertGroupMemberships do
+  alias App.Adapter.D4H
+  alias App.Model.Group
+  alias App.Model.GroupMember
+  alias App.Model.Member
+  alias App.Operation.RefreshD4HData.Progress
+
+  def call(d4h, team, progress) when is_map(d4h) when is_map(team) do
+    context = %{
+      d4h: d4h,
+      team_id: team.id,
+      d4h_member_index: build_d4h_member_index(team.id),
+      d4h_group_index: build_d4h_group_index(team.id),
+      progress: progress,
+      total_count: 0
+    }
+
+    fetch_and_upsert(context, 0)
+  end
+
+  defp fetch_and_upsert(context, page) do
+    d4h_memberships = D4H.fetch_group_memberships(context.d4h, page)
+    upsert_memberships(context, page, d4h_memberships)
+  end
+
+  defp build_d4h_member_index(team_id) do
+    team_id
+    |> Member.get_all()
+    |> Enum.map(fn r -> {r.d4h_member_id, r.id} end)
+    |> Map.new()
+  end
+
+  defp build_d4h_group_index(team_id) do
+    team_id
+    |> Group.get_all()
+    |> Enum.map(fn r -> {r.d4h_group_id, r.id} end)
+    |> Map.new()
+  end
+
+  defp upsert_memberships(context, _page, []) do
+    {context.total_count, context.progress}
+  end
+
+  defp upsert_memberships(context, page, d4h_memberships) do
+    count = Enum.count(d4h_memberships)
+
+    Enum.each(d4h_memberships, &upsert_membership(context, &1))
+
+    progress = Progress.add_page(context.progress, count)
+    context = %{context | progress: progress, total_count: context.total_count + count}
+    fetch_and_upsert(context, page + 1)
+  end
+
+  defp upsert_membership(context, d4h_membership) do
+    member_id = context.d4h_member_index[d4h_membership.d4h_member_id]
+    group_id = context.d4h_group_index[d4h_membership.d4h_group_id]
+    upsert_membership(member_id, group_id, d4h_membership)
+  end
+
+  defp upsert_membership(nil, _group_id, _d4h_membership), do: :skip
+  defp upsert_membership(_member_id, nil, _d4h_membership), do: :skip
+
+  defp upsert_membership(member_id, group_id, d4h_membership) do
+    params = %{
+      member_id: member_id,
+      group_id: group_id,
+      d4h_group_membership_id: d4h_membership.d4h_group_membership_id
+    }
+
+    group_member =
+      GroupMember.get_by(
+        group_id: group_id,
+        member_id: member_id
+      )
+
+    if group_member do
+      GroupMember.update!(group_member, params)
+    else
+      GroupMember.insert!(params)
+    end
+  end
+end

--- a/lib/app/operation/RefreshD4HData/upsert_groups.ex
+++ b/lib/app/operation/RefreshD4HData/upsert_groups.ex
@@ -1,0 +1,44 @@
+defmodule App.Operation.RefreshD4HData.UpsertGroups do
+  alias App.Adapter.D4H
+  alias App.Model.Group
+  alias App.Operation.RefreshD4HData.Progress
+
+  @chunk_size 100
+
+  def call(d4h, team, progress) do
+    d4h_groups = D4H.fetch_groups(d4h)
+    total_count = Enum.count(d4h_groups)
+
+    progress = Progress.update_stage(progress, "Groups", total_count)
+
+    chunks = Enum.chunk_every(d4h_groups, @chunk_size)
+
+    progress =
+      Enum.reduce(chunks, progress, fn chunk, progress_acc ->
+        Enum.each(chunk, &upsert_group(team, &1))
+        Progress.add_page(progress_acc, Enum.count(chunk))
+      end)
+
+    {total_count, progress}
+  end
+
+  defp upsert_group(team, d4h_group) do
+    params = %{
+      team_id: team.id,
+      d4h_group_id: d4h_group.d4h_group_id,
+      title: d4h_group.title
+    }
+
+    group =
+      Group.get_by(
+        team_id: team.id,
+        d4h_group_id: d4h_group.d4h_group_id
+      )
+
+    if group do
+      Group.update!(group, params)
+    else
+      Group.insert!(params)
+    end
+  end
+end

--- a/lib/app/operation/refresh_d4h_data.ex
+++ b/lib/app/operation/refresh_d4h_data.ex
@@ -33,6 +33,7 @@ defmodule App.Operation.RefreshD4HData do
     {tag_index, progress} = refresh_members_and_tags(d4h, team, progress)
     progress = refresh_all_activities(d4h, team, tag_index, progress)
     progress = refresh_qualifications(d4h, team, progress)
+    progress = refresh_groups(d4h, team, progress)
 
     RefreshD4HData.Progress.complete(progress)
     {:ok, update_team_refreshed_at(team)}
@@ -82,6 +83,16 @@ defmodule App.Operation.RefreshD4HData do
 
     progress = RefreshD4HData.Progress.update_stage(progress, "Qualification Awards")
     {_count, progress} = RefreshD4HData.UpsertQualificationAwards.call(d4h, team, progress)
+    RefreshD4HData.Progress.finish_stage(progress)
+  end
+
+  defp refresh_groups(d4h, team, progress) do
+    progress = RefreshD4HData.Progress.update_stage(progress, "Groups")
+    {_count, progress} = RefreshD4HData.UpsertGroups.call(d4h, team, progress)
+    progress = RefreshD4HData.Progress.finish_stage(progress)
+
+    progress = RefreshD4HData.Progress.update_stage(progress, "Group Memberships")
+    {_count, progress} = RefreshD4HData.UpsertGroupMemberships.call(d4h, team, progress)
     RefreshD4HData.Progress.finish_stage(progress)
   end
 

--- a/lib/app/view_data/team_dashboard_view_data.ex
+++ b/lib/app/view_data/team_dashboard_view_data.ex
@@ -4,6 +4,8 @@ defmodule App.ViewData.TeamDashboardViewData do
   alias App.Model.Activity
   alias App.Model.Attendance
   alias App.Model.Member
+  alias App.Model.Group
+  alias App.Model.GroupMember
   alias App.Model.MemberQualificationAward
   alias App.Model.Qualification
   alias App.Repo
@@ -17,6 +19,8 @@ defmodule App.ViewData.TeamDashboardViewData do
       attendance_count: count_attendances(team),
       qualification_count: count_qualifications(team),
       qualification_award_count: count_qualification_awards(team),
+      group_count: count_groups(team),
+      group_member_count: count_group_members(team),
       refreshed_at: team.d4h_refreshed_at,
       refresh_result: refresh_result_value(team, refreshing?)
     }
@@ -71,6 +75,19 @@ defmodule App.ViewData.TeamDashboardViewData do
     MemberQualificationAward
     |> join(:left, [a], m in assoc(a, :member))
     |> where([_, m], m.team_id == ^team.id)
+    |> select(count(1))
+    |> Repo.one()
+  end
+
+  def count_groups(team) do
+    query = from g in Group, where: g.team_id == ^team.id, select: count(1)
+    Repo.one(query)
+  end
+
+  def count_group_members(team) do
+    GroupMember
+    |> join(:left, [gm], g in assoc(gm, :group))
+    |> where([_, g], g.team_id == ^team.id)
     |> select(count(1))
     |> Repo.one()
   end

--- a/lib/web/components/member_tabs.ex
+++ b/lib/web/components/member_tabs.ex
@@ -4,7 +4,7 @@ defmodule Web.Components.MemberTabs do
   import Web.Components.A
 
   attr :member, :map, required: true
-  attr :active_tab, :atom, required: true, values: [:attendance, :qualifications]
+  attr :active_tab, :atom, required: true, values: [:attendance, :qualifications, :groups]
 
   def member_tabs(assigns) do
     ~H"""
@@ -29,6 +29,16 @@ defmodule Web.Components.MemberTabs do
           ]}
         >
           Qualifications
+        </.a>
+        <.a
+          navigate={~p"/#{@member.team.subdomain}/members/#{@member.id}/groups"}
+          class={[
+            "py-3 px-4 font-medium text-sm border-b-2 transition-colors duration-200",
+            (@active_tab == :groups && "border-blue-500 text-blue-600 bg-blue-50") ||
+              "border-transparent text-gray-500 hover:text-gray-700 hover:bg-gray-100"
+          ]}
+        >
+          Groups
         </.a>
       </nav>
     </div>

--- a/lib/web/live/group_collection_live.ex
+++ b/lib/web/live/group_collection_live.ex
@@ -1,0 +1,58 @@
+defmodule Web.GroupCollectionLive do
+  use Web, :live_view_app_layout
+
+  import Ecto.Query
+
+  alias App.Model.Group
+  alias App.Model.GroupMember
+  alias App.Repo
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :page_title, "Groups")}
+  end
+
+  def handle_params(_params, _uri, socket) do
+    current_team = socket.assigns.current_team
+    groups = list_groups_with_counts(current_team)
+
+    socket =
+      socket
+      |> assign(:groups, groups)
+
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs team={@current_team} />
+    <h1 class="title mb-p">{@page_title}</h1>
+
+    <p class="mb-p text-secondary-1 text-sm">{length(@groups)} groups</p>
+
+    <.table id="group_collection" rows={@groups} class="w-full table-striped">
+      <:col :let={g} label="Group">
+        <.a navigate={~p"/#{@current_team.subdomain}/groups/#{g.id}"}>{g.title}</.a>
+      </:col>
+      <:col :let={g} label="Members" class="w-px whitespace-nowrap" align="right">
+        {g.member_count}
+      </:col>
+    </.table>
+
+    <p :if={@groups == []} class="text-secondary-1">No groups found.</p>
+    """
+  end
+
+  defp list_groups_with_counts(team) do
+    Group
+    |> where([g], g.team_id == ^team.id)
+    |> join(:left, [g], gm in GroupMember, on: gm.group_id == g.id)
+    |> group_by([g], [g.id, g.title])
+    |> order_by([g], asc: g.title)
+    |> select([g, gm], %{
+      id: g.id,
+      title: g.title,
+      member_count: count(gm.id)
+    })
+    |> Repo.all()
+  end
+end

--- a/lib/web/live/group_live.ex
+++ b/lib/web/live/group_live.ex
@@ -1,0 +1,101 @@
+defmodule Web.GroupLive do
+  use Web, :live_view_app_layout
+
+  import Ecto.Query
+
+  alias App.Adapter.D4H
+  alias App.Model.Group
+  alias App.Model.GroupMember
+  alias App.Repo
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(params, _uri, socket) do
+    current_team = socket.assigns.current_team
+    group = find_group(params["id"], current_team.id)
+    members = list_members_for_group(group)
+
+    socket =
+      socket
+      |> assign(:page_title, group.title)
+      |> assign(:group, group)
+      |> assign(:members, members)
+
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs team={@current_team}>
+      <:item label="Groups" path={~p"/#{@current_team.subdomain}/groups"} />
+      <:item label={@group.title} />
+    </.breadcrumbs>
+
+    <h1 class="title">{@group.title}</h1>
+
+    <div class="content-wrapper">
+      <aside class="content-1/3">
+        <.sidebar_content group={@group} members={@members} team={@current_team} />
+      </aside>
+      <main class="content-2/3">
+        <.main_content members={@members} team={@current_team} />
+      </main>
+    </div>
+    """
+  end
+
+  defp sidebar_content(assigns) do
+    ~H"""
+    <dl>
+      <dt>Actions</dt>
+      <dd>
+        <ul class="action-list">
+          <li>
+            <.a external={true} href={D4H.build_url(@team, "/team/members")}>
+              Open D4H Members
+            </.a>
+          </li>
+        </ul>
+      </dd>
+      <dt>Members</dt>
+      <dd>{length(@members)}</dd>
+    </dl>
+    """
+  end
+
+  defp main_content(assigns) do
+    ~H"""
+    <h2 class="subtitle mb-p05">Members ({length(@members)})</h2>
+    <.table
+      :if={@members != []}
+      id="group_members"
+      rows={@members}
+      class="w-full table-striped"
+    >
+      <:col :let={gm} label="Member">
+        <.a navigate={~p"/#{@team.subdomain}/members/#{gm.member.id}"}>
+          {gm.member.name}
+        </.a>
+      </:col>
+    </.table>
+    <p :if={@members == []} class="text-secondary-1">No members found.</p>
+    """
+  end
+
+  defp find_group(id, team_id) do
+    Group
+    |> where([g], g.id == ^id and g.team_id == ^team_id)
+    |> Repo.one!()
+  end
+
+  defp list_members_for_group(group) do
+    GroupMember
+    |> where([gm], gm.group_id == ^group.id)
+    |> join(:inner, [gm], m in assoc(gm, :member))
+    |> order_by([gm, m], asc: m.name)
+    |> preload([gm, m], member: m)
+    |> Repo.all()
+  end
+end

--- a/lib/web/live/member_groups_live.ex
+++ b/lib/web/live/member_groups_live.ex
@@ -1,0 +1,80 @@
+defmodule Web.MemberGroupsLive do
+  use Web, :live_view_app_layout
+
+  import Ecto.Query
+  import Web.Components.MemberSidebar
+  import Web.Components.MemberTabs
+
+  alias App.Model.GroupMember
+  alias App.Model.Member
+  alias App.Repo
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(params, _uri, socket) do
+    member = find_member(params["id"])
+
+    socket =
+      socket
+      |> assign(:page_title, "#{member.name} - Groups")
+      |> assign(:member, member)
+
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.breadcrumbs team={@current_team}>
+      <:item label="Members" path={~p"/#{@current_team.subdomain}/members/"} />
+      <:item label="Groups" />
+    </.breadcrumbs>
+
+    <h1 class="title">{@member.name}</h1>
+    <div class="content-wrapper">
+      <aside class="content-1/3">
+        <.sidebar_content member={@member} />
+      </aside>
+      <main class="content-2/3">
+        <.member_tabs member={@member} active_tab={:groups} />
+        <.groups_content member={@member} />
+      </main>
+    </div>
+    """
+  end
+
+  defp groups_content(assigns) do
+    ~H"""
+    <.table
+      :if={@member.group_members != []}
+      id="member_groups"
+      rows={@member.group_members}
+      class="w-full table-striped"
+    >
+      <:col :let={gm} label="Group">
+        <.a navigate={~p"/#{@member.team.subdomain}/groups/#{gm.group.id}"}>
+          {gm.group.title}
+        </.a>
+      </:col>
+    </.table>
+    <p :if={@member.group_members == []}>No groups found.</p>
+    """
+  end
+
+  defp find_member(member_id) do
+    group_members_query =
+      from(gm in GroupMember,
+        join: g in assoc(gm, :group),
+        order_by: [asc: g.title],
+        preload: [group: g]
+      )
+
+    Member
+    |> Repo.get(member_id)
+    |> Repo.preload([
+      :team,
+      group_members: group_members_query
+    ])
+  end
+end

--- a/lib/web/live/team_dashboard_live.ex
+++ b/lib/web/live/team_dashboard_live.ex
@@ -59,6 +59,9 @@ defmodule Web.TeamDashboardLive do
         <.a navigate={~p"/#{@team.subdomain}/members"}>Members</.a>
         <ul class="subheading action-list ml-hindent">
           <li>
+            <.a navigate={~p"/#{@team.subdomain}/groups"}>Groups</.a>
+          </li>
+          <li>
             <.a navigate={~p"/#{@team.subdomain}/qualifications"}>Qualifications</.a>
           </li>
           <li>
@@ -113,6 +116,10 @@ defmodule Web.TeamDashboardLive do
       <dd>{@view_data.qualification_count}</dd>
       <dt>Qualification Awards</dt>
       <dd>{@view_data.qualification_award_count}</dd>
+      <dt>Groups</dt>
+      <dd>{@view_data.group_count}</dd>
+      <dt>Group Members</dt>
+      <dd>{@view_data.group_member_count}</dd>
     </dl>
     """
   end
@@ -153,7 +160,9 @@ defmodule Web.TeamDashboardLive do
     "Incidents",
     "Attendances",
     "Qualifications",
-    "Qualification Awards"
+    "Qualification Awards",
+    "Groups",
+    "Group Memberships"
   ]
 
   defp refreshing?(view_data) do

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -86,7 +86,10 @@ defmodule Web.Router do
       live "/:subdomain/activities/:id/mileage", ActivityMileageLive
       live "/:subdomain/members", MemberCollectionLive
       live "/:subdomain/members/:id", MemberLive
+      live "/:subdomain/members/:id/groups", MemberGroupsLive
       live "/:subdomain/members/:id/qualifications", MemberQualificationsLive
+      live "/:subdomain/groups", GroupCollectionLive
+      live "/:subdomain/groups/:id", GroupLive
       live "/:subdomain/qualifications", QualificationCollectionLive
       live "/:subdomain/qualifications/:id", QualificationLive
       live "/:subdomain/tax-credit-letters", TaxCreditLetterCollectionLive

--- a/priv/repo/migrations/20260307000000_create_groups_and_group_members.exs
+++ b/priv/repo/migrations/20260307000000_create_groups_and_group_members.exs
@@ -1,0 +1,25 @@
+defmodule App.Repo.Migrations.CreateGroupsAndGroupMembers do
+  use Ecto.Migration
+
+  def change do
+    create table(:groups) do
+      add :team_id, references(:teams), null: false
+      add :d4h_group_id, :integer, null: false
+      add :title, :string, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:groups, [:team_id, :d4h_group_id])
+
+    create table(:group_members) do
+      add :group_id, references(:groups), null: false
+      add :member_id, references(:members), null: false
+      add :d4h_group_membership_id, :integer, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:group_members, [:group_id, :member_id])
+  end
+end


### PR DESCRIPTION
## Summary
- Add `groups` and `group_members` database tables with D4H sync integration
- Fetch member groups and group memberships from D4H API during data refresh
- Add `/:team/groups`, `/:team/groups/:id`, and `/:team/members/:id/groups` LiveView pages
- Add Groups navigation link on team dashboard with counts, and Groups tab on member pages

## Test plan
- [x] Run `mix ecto.migrate` to create the new tables
- [x] Trigger a D4H data refresh and verify groups and group memberships sync
- [x] Browse `/:team/groups` and verify group list with member counts
- [x] Browse `/:team/groups/:id` and verify member list for a group
- [x] Browse `/:team/members/:id/groups` and verify groups tab shows member's groups
- [x] Verify Groups link appears on team dashboard under Members
- [x] Verify group/group member counts appear in dashboard sidebar
