### PR TITLE
Add group qualification rules

### DIFF
--- a/lib/app/model/group_rule_clause.ex
+++ b/lib/app/model/group_rule_clause.ex
@@ -1,0 +1,46 @@
+defmodule App.Model.GroupRuleClause do
+  use App, :model
+
+  alias App.Model.GroupRuleClause
+  alias App.Model.GroupRuleClauseQualification
+  alias App.Model.Team
+  alias App.Repo
+
+  schema "group_rule_clauses" do
+    belongs_to :team, Team
+    has_many :group_rule_clause_qualifications, GroupRuleClauseQualification, on_delete: :delete_all
+    field :d4h_group_id, :integer
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def build_new_changeset(params \\ %{}), do: build_changeset(%GroupRuleClause{}, params)
+
+  def build_changeset(data, params \\ %{}) do
+    data
+    |> cast(params, [
+      :team_id,
+      :d4h_group_id
+    ])
+    |> validate_required([
+      :team_id,
+      :d4h_group_id
+    ])
+  end
+
+  def get_all_for_group(team_id, d4h_group_id) do
+    GroupRuleClause
+    |> where([c], c.team_id == ^team_id and c.d4h_group_id == ^d4h_group_id)
+    |> preload(group_rule_clause_qualifications: [])
+    |> order_by([c], asc: c.id)
+    |> Repo.all()
+  end
+
+  def insert!(params) do
+    changeset = GroupRuleClause.build_new_changeset(params)
+    Repo.insert!(changeset)
+  end
+
+  def delete!(id) do
+    Repo.get!(GroupRuleClause, id) |> Repo.delete!()
+  end
+end

--- a/lib/app/model/group_rule_clause_qualification.ex
+++ b/lib/app/model/group_rule_clause_qualification.ex
@@ -1,0 +1,37 @@
+defmodule App.Model.GroupRuleClauseQualification do
+  use App, :model
+
+  alias App.Model.GroupRuleClause
+  alias App.Model.GroupRuleClauseQualification
+  alias App.Repo
+
+  schema "group_rule_clause_qualifications" do
+    belongs_to :group_rule_clause, GroupRuleClause
+    field :d4h_qualification_id, :integer
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def build_new_changeset(params \\ %{}), do: build_changeset(%GroupRuleClauseQualification{}, params)
+
+  def build_changeset(data, params \\ %{}) do
+    data
+    |> cast(params, [
+      :group_rule_clause_id,
+      :d4h_qualification_id
+    ])
+    |> validate_required([
+      :group_rule_clause_id,
+      :d4h_qualification_id
+    ])
+    |> unique_constraint([:group_rule_clause_id, :d4h_qualification_id])
+  end
+
+  def insert!(params) do
+    changeset = GroupRuleClauseQualification.build_new_changeset(params)
+    Repo.insert!(changeset)
+  end
+
+  def delete!(id) do
+    Repo.get!(GroupRuleClauseQualification, id) |> Repo.delete!()
+  end
+end

--- a/lib/web/live/group_live.ex
+++ b/lib/web/live/group_live.ex
@@ -6,6 +6,10 @@ defmodule Web.GroupLive do
   alias App.Adapter.D4H
   alias App.Model.Group
   alias App.Model.GroupMember
+  alias App.Model.GroupRuleClause
+  alias App.Model.GroupRuleClauseQualification
+  alias App.Model.MemberQualificationAward
+  alias App.Model.Qualification
   alias App.Repo
 
   def mount(_params, _session, socket) do
@@ -16,14 +20,52 @@ defmodule Web.GroupLive do
     current_team = socket.assigns.current_team
     group = find_group(params["id"], current_team.id)
     members = list_members_for_group(group)
+    clauses = GroupRuleClause.get_all_for_group(current_team.id, group.d4h_group_id)
+    qualifications = Qualification.get_all(current_team.id)
+    preview = compute_preview(clauses, qualifications, members, current_team.id)
 
     socket =
       socket
       |> assign(:page_title, group.title)
       |> assign(:group, group)
       |> assign(:members, members)
+      |> assign(:clauses, clauses)
+      |> assign(:qualifications, qualifications)
+      |> assign(:preview, preview)
 
     {:noreply, socket}
+  end
+
+  def handle_event("add-clause", _params, socket) do
+    group = socket.assigns.group
+    team = socket.assigns.current_team
+
+    GroupRuleClause.insert!(%{team_id: team.id, d4h_group_id: group.d4h_group_id})
+
+    {:noreply, reload(socket)}
+  end
+
+  def handle_event("delete-clause", %{"clause-id" => clause_id}, socket) do
+    GroupRuleClause.delete!(clause_id)
+
+    {:noreply, reload(socket)}
+  end
+
+  def handle_event("add-qualification", %{"clause-id" => clause_id, "qualification-id" => qual_id}, socket) do
+    if qual_id != "" do
+      GroupRuleClauseQualification.insert!(%{
+        group_rule_clause_id: clause_id,
+        d4h_qualification_id: find_qualification_d4h_id(socket.assigns.qualifications, qual_id)
+      })
+    end
+
+    {:noreply, reload(socket)}
+  end
+
+  def handle_event("remove-qualification", %{"qualification-id" => qual_id}, socket) do
+    GroupRuleClauseQualification.delete!(qual_id)
+
+    {:noreply, reload(socket)}
   end
 
   def render(assigns) do
@@ -40,6 +82,12 @@ defmodule Web.GroupLive do
         <.sidebar_content group={@group} members={@members} team={@current_team} />
       </aside>
       <main class="content-2/3">
+        <.clause_editor
+          clauses={@clauses}
+          qualifications={@qualifications}
+          team={@current_team}
+        />
+        <.rule_preview preview={@preview} team={@current_team} clauses={@clauses} />
         <.main_content members={@members} team={@current_team} />
       </main>
     </div>
@@ -65,9 +113,105 @@ defmodule Web.GroupLive do
     """
   end
 
+  defp clause_editor(assigns) do
+    ~H"""
+    <h2 class="subtitle mb-p05">Qualification Rules</h2>
+    <p :if={@clauses == []} class="text-secondary-1 mb-p">
+      No rules defined. Add a clause to define which qualifications members must hold.
+    </p>
+
+    <div :for={clause <- @clauses} class="mb-p border rounded p-p">
+      <div class="flex justify-between items-center mb-p05">
+        <h3 class="font-semibold">Clause — member must hold ANY of:</h3>
+        <button
+          phx-click="delete-clause"
+          phx-value-clause-id={clause.id}
+          class="btn btn-sm btn-danger"
+          data-confirm="Delete this clause and all its qualifications?"
+        >
+          Delete clause
+        </button>
+      </div>
+
+      <div class="flex flex-wrap gap-2 mb-p05">
+        <span
+          :for={cq <- clause.group_rule_clause_qualifications}
+          class="inline-flex items-center gap-1 rounded bg-base-200 px-2 py-1 text-sm"
+        >
+          {qualification_title(@qualifications, cq.d4h_qualification_id)}
+          <button
+            phx-click="remove-qualification"
+            phx-value-qualification-id={cq.id}
+            class="text-danger-1 hover:text-danger-2 font-bold"
+            title="Remove"
+          >
+            &times;
+          </button>
+        </span>
+        <span
+          :if={clause.group_rule_clause_qualifications == []}
+          class="text-secondary-1 text-sm italic"
+        >
+          No qualifications added yet
+        </span>
+      </div>
+
+      <form phx-submit="add-qualification" class="flex gap-2 items-end">
+        <input type="hidden" name="clause-id" value={clause.id} />
+        <select name="qualification-id" class="block rounded border shadow-sm text-sm">
+          <option value="">Add qualification...</option>
+          {Phoenix.HTML.Form.options_for_select(
+            available_qualifications(@qualifications, clause.group_rule_clause_qualifications),
+            nil
+          )}
+        </select>
+        <button type="submit" class="btn btn-sm">Add</button>
+      </form>
+    </div>
+
+    <button phx-click="add-clause" class="btn btn-sm">
+      + Add clause
+    </button>
+    """
+  end
+
+  defp rule_preview(assigns) do
+    ~H"""
+    <div :if={@clauses != []} class="mt-p">
+      <h2 class="subtitle mb-p05">Rule Preview</h2>
+      <p class="text-secondary-1 text-sm mb-p05">
+        Shows what would change if these rules were applied to the group.
+      </p>
+
+      <div :if={@preview.to_add != [] || @preview.to_remove != []} class="grid grid-cols-2 gap-p">
+        <div :if={@preview.to_add != []}>
+          <h3 class="font-semibold text-success-1 mb-p05">Would be added ({length(@preview.to_add)})</h3>
+          <ul class="text-sm">
+            <li :for={member <- @preview.to_add}>
+              <.a navigate={~p"/#{@team.subdomain}/members/#{member.id}"}>{member.name}</.a>
+            </li>
+          </ul>
+        </div>
+        <div :if={@preview.to_remove != []}>
+          <h3 class="font-semibold text-danger-1 mb-p05">Would be removed ({length(@preview.to_remove)})</h3>
+          <ul class="text-sm">
+            <li :for={member <- @preview.to_remove}>
+              <.a navigate={~p"/#{@team.subdomain}/members/#{member.id}"}>{member.name}</.a>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <p :if={@preview.to_add == [] && @preview.to_remove == []} class="text-secondary-1 text-sm">
+        No changes — current group membership matches the rules.
+      </p>
+    </div>
+    """
+  end
+
   defp main_content(assigns) do
     ~H"""
-    <h2 class="subtitle mb-p05">Members ({length(@members)})</h2>
+    <h2 class="subtitle mb-p05 mt-p">Members ({length(@members)})</h2>
     <.table
       :if={@members != []}
       id="group_members"
@@ -84,6 +228,19 @@ defmodule Web.GroupLive do
     """
   end
 
+  defp reload(socket) do
+    group = socket.assigns.group
+    team = socket.assigns.current_team
+    members = socket.assigns.members
+    clauses = GroupRuleClause.get_all_for_group(team.id, group.d4h_group_id)
+    qualifications = socket.assigns.qualifications
+    preview = compute_preview(clauses, qualifications, members, team.id)
+
+    socket
+    |> assign(:clauses, clauses)
+    |> assign(:preview, preview)
+  end
+
   defp find_group(id, team_id) do
     Group
     |> where([g], g.id == ^id and g.team_id == ^team_id)
@@ -97,5 +254,93 @@ defmodule Web.GroupLive do
     |> order_by([gm, m], asc: m.name)
     |> preload([gm, m], member: m)
     |> Repo.all()
+  end
+
+  defp qualification_title(qualifications, d4h_qualification_id) do
+    case Enum.find(qualifications, &(&1.d4h_qualification_id == d4h_qualification_id)) do
+      nil -> "Unknown (#{d4h_qualification_id})"
+      q -> q.title
+    end
+  end
+
+  defp find_qualification_d4h_id(qualifications, id) do
+    qual = Enum.find(qualifications, &(to_string(&1.id) == to_string(id)))
+    qual && qual.d4h_qualification_id
+  end
+
+  defp available_qualifications(qualifications, existing_clause_quals) do
+    existing_d4h_ids = MapSet.new(existing_clause_quals, & &1.d4h_qualification_id)
+
+    qualifications
+    |> Enum.reject(&MapSet.member?(existing_d4h_ids, &1.d4h_qualification_id))
+    |> Enum.map(&{&1.title, &1.id})
+  end
+
+  defp compute_preview(clauses, qualifications, current_group_members, team_id) do
+    if clauses == [] || Enum.any?(clauses, &(&1.group_rule_clause_qualifications == [])) do
+      %{to_add: [], to_remove: []}
+    else
+      qualifying_member_ids = compute_qualifying_members(clauses, qualifications, team_id)
+      current_member_ids = MapSet.new(current_group_members, & &1.member.id)
+
+      to_add =
+        qualifying_member_ids
+        |> MapSet.difference(current_member_ids)
+        |> load_members()
+
+      to_remove =
+        current_member_ids
+        |> MapSet.difference(qualifying_member_ids)
+        |> load_members()
+
+      %{to_add: to_add, to_remove: to_remove}
+    end
+  end
+
+  defp compute_qualifying_members(clauses, qualifications, team_id) do
+    # For each clause, find the set of members who hold any qualification in that clause
+    # Then intersect all clause sets (CNF: all clauses must pass)
+    clause_member_sets =
+      Enum.map(clauses, fn clause ->
+        d4h_qual_ids =
+          Enum.map(clause.group_rule_clause_qualifications, & &1.d4h_qualification_id)
+
+        qual_ids =
+          qualifications
+          |> Enum.filter(&(&1.d4h_qualification_id in d4h_qual_ids))
+          |> Enum.map(& &1.id)
+
+        if qual_ids == [] do
+          MapSet.new()
+        else
+          MemberQualificationAward
+          |> where([a], a.qualification_id in ^qual_ids)
+          |> where([a], is_nil(a.ends_at) or a.ends_at > ^DateTime.utc_now())
+          |> join(:inner, [a], m in assoc(a, :member))
+          |> where([a, m], m.team_id == ^team_id)
+          |> select([a], a.member_id)
+          |> distinct(true)
+          |> Repo.all()
+          |> MapSet.new()
+        end
+      end)
+
+    case clause_member_sets do
+      [] -> MapSet.new()
+      [first | rest] -> Enum.reduce(rest, first, &MapSet.intersection(&2, &1))
+    end
+  end
+
+  defp load_members(member_ids) do
+    ids = MapSet.to_list(member_ids)
+
+    if ids == [] do
+      []
+    else
+      App.Model.Member
+      |> where([m], m.id in ^ids)
+      |> order_by([m], asc: m.name)
+      |> Repo.all()
+    end
   end
 end

--- a/lib/web/live/group_live.ex
+++ b/lib/web/live/group_live.ex
@@ -116,17 +116,18 @@ defmodule Web.GroupLive do
   defp clause_editor(assigns) do
     ~H"""
     <h2 class="subtitle mb-p05">Qualification Rules</h2>
-    <p :if={@clauses == []} class="text-secondary-1 mb-p">
-      No rules defined. Add a clause to define which qualifications members must hold.
+    <p class="text-secondary-1 mb-p">
+      Define which qualifications members must hold to belong to this group.
+      Automatic syncing based on these rules is coming in a future update.
     </p>
 
-    <div :for={clause <- @clauses} class="mb-p border rounded p-p">
+    <div :for={clause <- @clauses} class="mb-p border rounded px-p py-p05">
       <div class="flex justify-between items-center mb-p05">
         <h3 class="font-semibold">Clause — member must hold ANY of:</h3>
         <button
           phx-click="delete-clause"
           phx-value-clause-id={clause.id}
-          class="btn btn-sm btn-danger"
+          class="btn btn-sm btn-danger ml-p"
           data-confirm="Delete this clause and all its qualifications?"
         >
           Delete clause
@@ -136,7 +137,7 @@ defmodule Web.GroupLive do
       <div class="flex flex-wrap gap-2 mb-p05">
         <span
           :for={cq <- clause.group_rule_clause_qualifications}
-          class="inline-flex items-center gap-1 rounded bg-base-200 px-2 py-1 text-sm"
+          class="inline-flex items-center gap-2 rounded bg-base-200 px-2 py-1 text-sm"
         >
           {qualification_title(@qualifications, cq.d4h_qualification_id)}
           <button
@@ -158,7 +159,10 @@ defmodule Web.GroupLive do
 
       <form phx-submit="add-qualification" class="flex gap-2 items-end">
         <input type="hidden" name="clause-id" value={clause.id} />
-        <select name="qualification-id" class="block rounded border shadow-sm text-sm">
+        <select
+          name="qualification-id"
+          class="block rounded border shadow-sm text-sm max-w-xs truncate"
+        >
           <option value="">Add qualification...</option>
           {Phoenix.HTML.Form.options_for_select(
             available_qualifications(@qualifications, clause.group_rule_clause_qualifications),

--- a/priv/repo/migrations/20260307010000_create_group_rule_clauses.exs
+++ b/priv/repo/migrations/20260307010000_create_group_rule_clauses.exs
@@ -1,0 +1,30 @@
+defmodule App.Repo.Migrations.CreateGroupRuleClauses do
+  use Ecto.Migration
+
+  def change do
+    create table(:group_rule_clauses) do
+      add :team_id, references(:teams), null: false
+      add :d4h_group_id, :integer, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:group_rule_clauses, [:team_id, :d4h_group_id])
+
+    create table(:group_rule_clause_qualifications) do
+      add :group_rule_clause_id, references(:group_rule_clauses, on_delete: :delete_all),
+        null: false
+
+      add :d4h_qualification_id, :integer, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:group_rule_clause_qualifications, [:group_rule_clause_id])
+
+    create unique_index(:group_rule_clause_qualifications, [
+      :group_rule_clause_id,
+      :d4h_qualification_id
+    ])
+  end
+end


### PR DESCRIPTION
## Summary

- New `group_rule_clauses` and `group_rule_clause_qualifications` tables for defining CNF qualification rules on D4H groups
- Clause editor UI on the group details page to create/delete clauses and add/remove qualifications per clause
- Read-only preview showing which members would be added or removed if the rules were applied
- Rules use CNF logic: `(A OR B) AND (C OR D)` — a member qualifies if they satisfy every clause, and a clause is satisfied by holding any listed (non-expired) qualification

## Test plan

- [x] Navigate to a group details page and verify the "Qualification Rules" section appears
- [x] Add a clause via "+ Add clause" button
- [x] Add qualifications to a clause via the dropdown and verify they appear as tags
- [x] Remove a qualification tag with the × button
- [x] Delete a clause and confirm cascade deletes its qualifications
- [x] With rules defined, verify the "Rule Preview" section shows correct add/remove lists
- [x] Verify empty clauses suppress the preview (no false matches)
- [x] Run `mix test` — all 145 tests pass
